### PR TITLE
spaghetti 1.7.6 - rebuild with versioning metadata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
 
 build:
   skip: true  # [py<310]
-  number: 0
+  number: 1
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,9 @@ source:
 build:
   skip: true  # [py<310]
   number: 1
+  # Setting the version manually, otherwise despite the version assert and pip check in this recipe,
+  # other packages which depend on it will fail pip check with "PACKAGE has requirement spaghetti>=1.7.4, but you
+  # have spaghetti 0.0.0". This occurs since version 1.7.6
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv


### PR DESCRIPTION
spaghetti 1.7.6 - rebuild with versioning metadata

**Destination channel:** Defaults

### Links

- [PKG-9195]
- dev_url:        https://github.com/pysal/spaghetti/tree/v1.7.6
- conda_forge:    https://github.com/conda-forge/spaghetti-feedstock
- pypi:           https://pypi.org/project/spaghetti/1.7.6
- pypi inspector: https://inspector.pypi.io/project/spaghetti/1.7.6/

### Explanation of changes:

- new version number


[PKG-9195]: https://anaconda.atlassian.net/browse/PKG-9195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ